### PR TITLE
Add support for custom columns for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ vars:
     asana_schema: your_schema_name 
 ```
 
+To add addtional columns to tasks use the pass-through column variable.  This is useful for adding custom fields not already included in this package.
+
+```
+# dbt_project.yml
+
+...
+vars:
+  asana_source:
+    task_pass_through_columns: [custom_status, custom_department]
+```
+
 ### Changing the Build Schema
 By default this package will build the Asana staging models within a schema titled (<target_schema> + `_stg_asana`) in your target database. If this is not where you would like your Asana staging data to be written to, add the following configuration to your `dbt_project.yml` file:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,3 +23,4 @@ vars:
         task_tag:       "{{ source('asana', 'task_tag') }}"
         section:        "{{ source('asana', 'section') }}"
         task_section:   "{{ source('asana', 'task_section') }}"
+        task_pass_through_columns: []

--- a/models/stg_asana__task.sql
+++ b/models/stg_asana__task.sql
@@ -15,7 +15,14 @@ fields as (
                 staging_columns=get_task_columns()
             )
         }}
-        
+
+        --The below script allows for pass through columns.
+        {% if var('task_pass_through_columns') %}
+        ,
+        {{ var('task_pass_through_columns') | join (", ") }}
+
+        {% endif %}
+
     from base
 ),
 
@@ -36,6 +43,14 @@ final as (
         start_on as start_date,
         notes as task_description,
         workspace_id
+
+        --The below script allows for pass through columns.
+        {% if var('task_pass_through_columns') %}
+        ,
+        {{ var('task_pass_through_columns') | join (", ") }}
+
+        {% endif %}
+
     from fields
 )
 


### PR DESCRIPTION
Adds a `task_pass_through_colums` variable used to pass custom columns through to the transformation package.

This resolves #7 